### PR TITLE
preventDefault should come after false target check 

### DIFF
--- a/lib/js/stack.js
+++ b/lib/js/stack.js
@@ -51,9 +51,9 @@
 	var handleTouch = function (e) {
     var target = getTarget(e);
 
-    e.preventDefault();
-    
     if (!target) return;
+
+    e.preventDefault();
 
     doXHR({
       url: target.getAttribute('href'),


### PR DESCRIPTION
I was having issued with allowing the default execution of a "tel" hyperlink, despite setting data-ignore to true. I changed the location of the preventDefault statement to execute after the check for a false target and not before that and it worked for me.
